### PR TITLE
Compatibility for IDA 6.9

### DIFF
--- a/collabreate_ui.cpp
+++ b/collabreate_ui.cpp
@@ -402,6 +402,22 @@ bool do_choose_perms(Buffer &b) {
    return memcmp(&current, &tempOpts, sizeof(Options)) != 0;
 }
 
+#ifndef FORM_MDI
+#define FORM_MDI 0
+#endif
+
+void createCollabStatus() {
+	HWND hwnd = NULL;
+	TForm *form = create_tform("CollabREate", &hwnd);
+	if (hwnd != NULL) {
+		//hook_to_notification_point(HT_UI, ui_collab, form);
+		open_tform(form, FORM_MDI | FORM_TAB | FORM_MENU | FORM_RESTORE | FORM_QWIDGET);
+	}
+	else {
+		close_tform(form, FORM_SAVE);
+	}
+}
+
 bool sameDay(time_t t1, time_t t2) {
    tm tm1 = *localtime(&t1);
    tm tm2 = *localtime(&t2);

--- a/collabreate_ui.hpp
+++ b/collabreate_ui.hpp
@@ -29,6 +29,7 @@ bool do_connect(Dispatcher d);
 int  do_auth(unsigned char *challenge, int challenge_len);
 void do_set_req_perms(void);
 void do_set_proj_perms(void);
+void createCollabStatus();
 
 //void showOptionsDlg(HWND parent, Options *in, Options *out, Options *mask, char * title);
 


### PR DESCRIPTION
1. Update references to get_struc_name(), get_enum_name(), get_enum_member_name(), and get_member_name() to match the newer IDA 6.9 SDK.
2. Create a definition for createCollabStatus() in collabreate_ui.cpp and collabreate_ui.hpp
3. Don't check for IDA_SDK_VERSION < 600 in init(). It makes the mainWindow reference never get defined.
